### PR TITLE
Add dark mode toggle to app bar

### DIFF
--- a/app/components/app-bar.spec.tsx
+++ b/app/components/app-bar.spec.tsx
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "bun:test";
+import { PROJECT_NAME } from "@common/consts";
+import {
+	getElementsByTagName,
+	getTextContent,
+	parseJSXElement,
+} from "@/utils/html-parser";
+import { MyAppBar } from "./app-bar";
+
+describe("MyAppBar", () => {
+	it("should render header with default title", () => {
+		const jsx = <MyAppBar />;
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		expect(headers.length).toBe(1);
+		const header = headers[0];
+		if (!header) {
+			throw new Error("Expected header element to exist");
+		}
+
+		const h1Elements = getElementsByTagName(root, "h1");
+		expect(h1Elements.length).toBe(1);
+		const h1 = h1Elements[0];
+		if (!h1) {
+			throw new Error("Expected h1 element to exist");
+		}
+		expect(getTextContent(h1)).toBe(PROJECT_NAME);
+	});
+
+	it("should render with custom title", () => {
+		const jsx = <MyAppBar title="Custom Title" />;
+		const root = parseJSXElement(jsx);
+		const h1Elements = getElementsByTagName(root, "h1");
+
+		expect(h1Elements.length).toBe(1);
+		const h1 = h1Elements[0];
+		if (!h1) {
+			throw new Error("Expected h1 element to exist");
+		}
+		expect(getTextContent(h1)).toBe("Custom Title");
+	});
+
+	it("should have fixed positioning with correct height", () => {
+		const jsx = <MyAppBar />;
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		const header = headers[0];
+		if (!header) {
+			throw new Error("Expected header element to exist");
+		}
+		if (header.type === "Element") {
+			expect(header.attributes.class).toContain("fixed");
+			expect(header.attributes.class).toContain("top-0");
+			expect(header.attributes.class).toContain("left-0");
+			expect(header.attributes.class).toContain("right-0");
+			expect(header.attributes.class).toContain("h-16");
+		}
+	});
+
+	it("should have flex layout with centered items", () => {
+		const jsx = <MyAppBar />;
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		const header = headers[0];
+		if (!header) {
+			throw new Error("Expected header element to exist");
+		}
+		if (header.type === "Element") {
+			expect(header.attributes.class).toContain("flex");
+			expect(header.attributes.class).toContain("items-center");
+		}
+	});
+
+	it("should have background and shadow styles", () => {
+		const jsx = <MyAppBar />;
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		const header = headers[0];
+		if (!header) {
+			throw new Error("Expected header element to exist");
+		}
+		if (header.type === "Element") {
+			expect(header.attributes.class).toContain("bg-white");
+			expect(header.attributes.class).toContain("dark:bg-gray-800");
+			expect(header.attributes.class).toContain("shadow-md");
+		}
+	});
+
+	it("should render prepend content when provided", () => {
+		const jsx = <MyAppBar prepend={<span>Left Content</span>} />;
+		const root = parseJSXElement(jsx);
+		const spans = getElementsByTagName(root, "span");
+
+		const hasLeftContent = spans.some(
+			(span) => getTextContent(span) === "Left Content",
+		);
+		expect(hasLeftContent).toBe(true);
+	});
+
+	it("should not render prepend div when prepend is undefined", () => {
+		const jsx = <MyAppBar />;
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		const header = headers[0];
+		if (!header) {
+			throw new Error("Expected header element to exist");
+		}
+		if (header.type === "Element") {
+			// Should only have h1 as child (no prepend div)
+			const divChildren = header.children.filter(
+				(child) => child.type === "Element" && child.tagName === "div",
+			);
+			// Only the spacer div should exist, not prepend div
+			expect(divChildren.length).toBe(0);
+		}
+	});
+
+	it("should render append content when provided", () => {
+		const jsx = <MyAppBar append={<span>Right Content</span>} />;
+		const root = parseJSXElement(jsx);
+		const spans = getElementsByTagName(root, "span");
+
+		const hasRightContent = spans.some(
+			(span) => getTextContent(span) === "Right Content",
+		);
+		expect(hasRightContent).toBe(true);
+	});
+
+	it("should render both prepend and append content", () => {
+		const jsx = (
+			<MyAppBar
+				prepend={<span>Left</span>}
+				append={<span>Right</span>}
+				title="Center"
+			/>
+		);
+		const root = parseJSXElement(jsx);
+		const spans = getElementsByTagName(root, "span");
+
+		const hasLeft = spans.some((span) => getTextContent(span) === "Left");
+		const hasRight = spans.some((span) => getTextContent(span) === "Right");
+
+		expect(hasLeft).toBe(true);
+		expect(hasRight).toBe(true);
+
+		const h1Elements = getElementsByTagName(root, "h1");
+		const h1 = h1Elements[0];
+		if (!h1) {
+			throw new Error("Expected h1 element to exist");
+		}
+		expect(getTextContent(h1)).toBe("Center");
+	});
+
+	it("should have flex-1 on h1 for flexible width", () => {
+		const jsx = <MyAppBar />;
+		const root = parseJSXElement(jsx);
+		const h1Elements = getElementsByTagName(root, "h1");
+
+		const h1 = h1Elements[0];
+		if (!h1) {
+			throw new Error("Expected h1 element to exist");
+		}
+		if (h1.type === "Element") {
+			expect(h1.attributes.class).toContain("flex-1");
+		}
+	});
+
+	it("should render spacer div with h-16", () => {
+		const jsx = <MyAppBar />;
+		const root = parseJSXElement(jsx);
+		const divs = getElementsByTagName(root, "div");
+
+		// Find the spacer div (should be after header)
+		const spacerDiv = divs.find(
+			(div) =>
+				div.type === "Element" &&
+				div.attributes.class === "h-16" &&
+				div.children.length === 0,
+		);
+
+		expect(spacerDiv).toBeDefined();
+	});
+
+	it("should wrap prepend content in div with mx-5", () => {
+		const jsx = <MyAppBar prepend={<span>Left</span>} />;
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		const header = headers[0];
+		if (!header) {
+			throw new Error("Expected header element to exist");
+		}
+		if (header.type === "Element") {
+			const prependDiv = header.children.find(
+				(child) =>
+					child.type === "Element" &&
+					child.tagName === "div" &&
+					typeof child.attributes.class === "string" &&
+					child.attributes.class.includes("mx-5"),
+			);
+			expect(prependDiv).toBeDefined();
+		}
+	});
+
+	it("should wrap append content in div with mx-5", () => {
+		const jsx = <MyAppBar append={<span>Right</span>} />;
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		const header = headers[0];
+		if (!header) {
+			throw new Error("Expected header element to exist");
+		}
+		if (header.type === "Element") {
+			const appendDiv = header.children.find(
+				(child) =>
+					child.type === "Element" &&
+					child.tagName === "div" &&
+					typeof child.attributes.class === "string" &&
+					child.attributes.class.includes("mx-5"),
+			);
+			expect(appendDiv).toBeDefined();
+		}
+	});
+
+	it("should handle string prepend content", () => {
+		const jsx = <MyAppBar prepend="Left Text" />;
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		const header = headers[0];
+		if (!header) {
+			throw new Error("Expected header element to exist");
+		}
+		const textContent = getTextContent(header);
+		expect(textContent).toContain("Left Text");
+	});
+
+	it("should handle string append content", () => {
+		const jsx = <MyAppBar append="Right Text" />;
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		const header = headers[0];
+		if (!header) {
+			throw new Error("Expected header element to exist");
+		}
+		const textContent = getTextContent(header);
+		expect(textContent).toContain("Right Text");
+	});
+});

--- a/app/components/app-bar.spec.tsx
+++ b/app/components/app-bar.spec.tsx
@@ -8,8 +8,8 @@ import {
 import { MyAppBar } from "./app-bar";
 
 describe("MyAppBar", () => {
-	it("should render header with default title", () => {
-		const jsx = <MyAppBar />;
+	it("should render header with title", () => {
+		const jsx = <MyAppBar title={PROJECT_NAME} />;
 		const root = parseJSXElement(jsx);
 		const headers = getElementsByTagName(root, "header");
 
@@ -42,7 +42,7 @@ describe("MyAppBar", () => {
 	});
 
 	it("should have fixed positioning with correct height", () => {
-		const jsx = <MyAppBar />;
+		const jsx = <MyAppBar title="Test" />;
 		const root = parseJSXElement(jsx);
 		const headers = getElementsByTagName(root, "header");
 
@@ -60,7 +60,7 @@ describe("MyAppBar", () => {
 	});
 
 	it("should have flex layout with centered items", () => {
-		const jsx = <MyAppBar />;
+		const jsx = <MyAppBar title="Test" />;
 		const root = parseJSXElement(jsx);
 		const headers = getElementsByTagName(root, "header");
 
@@ -75,7 +75,7 @@ describe("MyAppBar", () => {
 	});
 
 	it("should have background and shadow styles", () => {
-		const jsx = <MyAppBar />;
+		const jsx = <MyAppBar title="Test" />;
 		const root = parseJSXElement(jsx);
 		const headers = getElementsByTagName(root, "header");
 
@@ -91,7 +91,7 @@ describe("MyAppBar", () => {
 	});
 
 	it("should render prepend content when provided", () => {
-		const jsx = <MyAppBar prepend={<span>Left Content</span>} />;
+		const jsx = <MyAppBar title="Test" prepend={<span>Left Content</span>} />;
 		const root = parseJSXElement(jsx);
 		const spans = getElementsByTagName(root, "span");
 
@@ -102,7 +102,7 @@ describe("MyAppBar", () => {
 	});
 
 	it("should not render prepend div when prepend is undefined", () => {
-		const jsx = <MyAppBar />;
+		const jsx = <MyAppBar title="Test" />;
 		const root = parseJSXElement(jsx);
 		const headers = getElementsByTagName(root, "header");
 
@@ -121,7 +121,7 @@ describe("MyAppBar", () => {
 	});
 
 	it("should render append content when provided", () => {
-		const jsx = <MyAppBar append={<span>Right Content</span>} />;
+		const jsx = <MyAppBar title="Test" append={<span>Right Content</span>} />;
 		const root = parseJSXElement(jsx);
 		const spans = getElementsByTagName(root, "span");
 
@@ -157,7 +157,7 @@ describe("MyAppBar", () => {
 	});
 
 	it("should have flex-1 on h1 for flexible width", () => {
-		const jsx = <MyAppBar />;
+		const jsx = <MyAppBar title="Test" />;
 		const root = parseJSXElement(jsx);
 		const h1Elements = getElementsByTagName(root, "h1");
 
@@ -171,7 +171,7 @@ describe("MyAppBar", () => {
 	});
 
 	it("should render spacer div with h-16", () => {
-		const jsx = <MyAppBar />;
+		const jsx = <MyAppBar title="Test" />;
 		const root = parseJSXElement(jsx);
 		const divs = getElementsByTagName(root, "div");
 
@@ -186,8 +186,8 @@ describe("MyAppBar", () => {
 		expect(spacerDiv).toBeDefined();
 	});
 
-	it("should wrap prepend content in div with mx-5", () => {
-		const jsx = <MyAppBar prepend={<span>Left</span>} />;
+	it("should wrap prepend content in div with ml-5", () => {
+		const jsx = <MyAppBar title="Test" prepend={<span>Left</span>} />;
 		const root = parseJSXElement(jsx);
 		const headers = getElementsByTagName(root, "header");
 
@@ -201,14 +201,14 @@ describe("MyAppBar", () => {
 					child.type === "Element" &&
 					child.tagName === "div" &&
 					typeof child.attributes.class === "string" &&
-					child.attributes.class.includes("mx-5"),
+					child.attributes.class.includes("ml-5"),
 			);
 			expect(prependDiv).toBeDefined();
 		}
 	});
 
-	it("should wrap append content in div with mx-5", () => {
-		const jsx = <MyAppBar append={<span>Right</span>} />;
+	it("should wrap append content in div with mr-5", () => {
+		const jsx = <MyAppBar title="Test" append={<span>Right</span>} />;
 		const root = parseJSXElement(jsx);
 		const headers = getElementsByTagName(root, "header");
 
@@ -222,14 +222,14 @@ describe("MyAppBar", () => {
 					child.type === "Element" &&
 					child.tagName === "div" &&
 					typeof child.attributes.class === "string" &&
-					child.attributes.class.includes("mx-5"),
+					child.attributes.class.includes("mr-5"),
 			);
 			expect(appendDiv).toBeDefined();
 		}
 	});
 
 	it("should handle string prepend content", () => {
-		const jsx = <MyAppBar prepend="Left Text" />;
+		const jsx = <MyAppBar title="Test" prepend="Left Text" />;
 		const root = parseJSXElement(jsx);
 		const headers = getElementsByTagName(root, "header");
 
@@ -242,7 +242,7 @@ describe("MyAppBar", () => {
 	});
 
 	it("should handle string append content", () => {
-		const jsx = <MyAppBar append="Right Text" />;
+		const jsx = <MyAppBar title="Test" append="Right Text" />;
 		const root = parseJSXElement(jsx);
 		const headers = getElementsByTagName(root, "header");
 

--- a/app/components/app-bar.tsx
+++ b/app/components/app-bar.tsx
@@ -1,0 +1,33 @@
+import { PROJECT_NAME } from "@common/consts";
+import type { JSX } from "hono/jsx/jsx-runtime";
+
+export interface MyAppBarProps {
+	title?: string;
+	prepend?:
+		| JSX.Element
+		| Array<JSX.Element>
+		| string
+		| Array<JSX.Element | string>;
+	append?:
+		| JSX.Element
+		| Array<JSX.Element>
+		| string
+		| Array<JSX.Element | string>;
+}
+
+export function MyAppBar({
+	title = PROJECT_NAME,
+	prepend,
+	append,
+}: MyAppBarProps) {
+	return (
+		<>
+			<header class="fixed top-0 left-0 right-0 h-16 bg-white dark:bg-gray-800 shadow-md flex items-center">
+				{prepend && <div class="mx-5">{prepend}</div>}
+				<h1 class="flex-1">{title}</h1>
+				{append && <div class="mx-5">{append}</div>}
+			</header>
+			<div class="h-16" />
+		</>
+	);
+}

--- a/app/components/app-bar.tsx
+++ b/app/components/app-bar.tsx
@@ -1,8 +1,7 @@
-import { PROJECT_NAME } from "@common/consts";
 import type { JSX } from "hono/jsx/jsx-runtime";
 
 export interface MyAppBarProps {
-	title?: string;
+	title: string;
 	prepend?:
 		| JSX.Element
 		| Array<JSX.Element>
@@ -15,17 +14,13 @@ export interface MyAppBarProps {
 		| Array<JSX.Element | string>;
 }
 
-export function MyAppBar({
-	title = PROJECT_NAME,
-	prepend,
-	append,
-}: MyAppBarProps) {
+export function MyAppBar({ title, prepend, append }: MyAppBarProps) {
 	return (
 		<>
 			<header class="fixed top-0 left-0 right-0 h-16 bg-white dark:bg-gray-800 shadow-md flex items-center">
-				{prepend && <div class="mx-5">{prepend}</div>}
-				<h1 class="flex-1">{title}</h1>
-				{append && <div class="mx-5">{append}</div>}
+				{prepend && <div class="ml-5">{prepend}</div>}
+				<h1 class="flex-1 ml-5">{title}</h1>
+				{append && <div class="mr-5">{append}</div>}
 			</header>
 			<div class="h-16" />
 		</>

--- a/app/components/icon.spec.tsx
+++ b/app/components/icon.spec.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getElementsByAttribute,
+	getElementsByTagName,
+	parseJSXElement,
+} from "@/utils/html-parser";
+import { MyIcon } from "./icon";
+
+describe("MyIcon", () => {
+	test("renders span element with mdi classes", () => {
+		const root = parseJSXElement(<MyIcon mdi="home" />);
+		const spans = getElementsByTagName(root, "span");
+
+		expect(spans.length).toBe(1);
+		const span = spans[0];
+		if (!span) throw new Error("Expected span element to exist");
+
+		if (span.type === "Element") {
+			expect(span.attributes.class).toContain("mdi");
+			expect(span.attributes.class).toContain("mdi-home");
+		}
+	});
+
+	test("applies medium size by default", () => {
+		const root = parseJSXElement(<MyIcon mdi="search" />);
+		const spans = getElementsByTagName(root, "span");
+
+		const span = spans[0];
+		if (!span) throw new Error("Expected span element to exist");
+
+		if (span.type === "Element") {
+			expect(span.attributes.class).toContain("text-xl");
+		}
+	});
+
+	test("applies small size when specified", () => {
+		const root = parseJSXElement(<MyIcon mdi="menu" size="small" />);
+		const spans = getElementsByTagName(root, "span");
+
+		const span = spans[0];
+		if (!span) throw new Error("Expected span element to exist");
+
+		if (span.type === "Element") {
+			expect(span.attributes.class).toContain("text-base");
+		}
+	});
+
+	test("applies large size when specified", () => {
+		const root = parseJSXElement(<MyIcon mdi="close" size="large" />);
+		const spans = getElementsByTagName(root, "span");
+
+		const span = spans[0];
+		if (!span) throw new Error("Expected span element to exist");
+
+		if (span.type === "Element") {
+			expect(span.attributes.class).toContain("text-2xl");
+		}
+	});
+
+	test("applies custom className", () => {
+		const root = parseJSXElement(
+			<MyIcon mdi="star" className="text-yellow-500" />,
+		);
+		const spans = getElementsByTagName(root, "span");
+
+		const span = spans[0];
+		if (!span) throw new Error("Expected span element to exist");
+
+		if (span.type === "Element") {
+			expect(span.attributes.class).toContain("text-yellow-500");
+		}
+	});
+
+	test("combines size and custom className", () => {
+		const root = parseJSXElement(
+			<MyIcon mdi="heart" size="large" className="text-red-500" />,
+		);
+		const spans = getElementsByTagName(root, "span");
+
+		const span = spans[0];
+		if (!span) throw new Error("Expected span element to exist");
+
+		if (span.type === "Element") {
+			expect(span.attributes.class).toContain("text-2xl");
+			expect(span.attributes.class).toContain("text-red-500");
+		}
+	});
+
+	test("includes aria-hidden attribute for accessibility", () => {
+		const root = parseJSXElement(<MyIcon mdi="info" />);
+		const spans = getElementsByAttribute(root, "aria-hidden");
+
+		expect(spans.length).toBe(1);
+		const span = spans[0];
+		if (!span) throw new Error("Expected span element to exist");
+
+		if (span.type === "Element") {
+			expect(span.attributes["aria-hidden"]).toBe("true");
+		}
+	});
+
+	test("handles icon names with hyphens", () => {
+		const root = parseJSXElement(<MyIcon mdi="weather-sunny" />);
+		const spans = getElementsByTagName(root, "span");
+
+		const span = spans[0];
+		if (!span) throw new Error("Expected span element to exist");
+
+		if (span.type === "Element") {
+			expect(span.attributes.class).toContain("mdi-weather-sunny");
+		}
+	});
+
+	test("renders different icons correctly", () => {
+		const icons = ["home", "search", "menu", "close", "star"];
+
+		for (const icon of icons) {
+			const root = parseJSXElement(<MyIcon mdi={icon} />);
+			const spans = getElementsByTagName(root, "span");
+
+			const span = spans[0];
+			if (!span) throw new Error(`Expected span element to exist for ${icon}`);
+
+			if (span.type === "Element") {
+				expect(span.attributes.class).toContain(`mdi-${icon}`);
+			}
+		}
+	});
+
+	test("all size variants have correct classes", () => {
+		const sizes = [
+			{ size: "small" as const, class: "text-base" },
+			{ size: "medium" as const, class: "text-xl" },
+			{ size: "large" as const, class: "text-2xl" },
+		];
+
+		for (const { size, class: expectedClass } of sizes) {
+			const root = parseJSXElement(<MyIcon mdi="test" size={size} />);
+			const spans = getElementsByTagName(root, "span");
+
+			const span = spans[0];
+			if (!span)
+				throw new Error(`Expected span element to exist for size ${size}`);
+
+			if (span.type === "Element") {
+				expect(span.attributes.class).toContain(expectedClass);
+			}
+		}
+	});
+});

--- a/app/components/icon.tsx
+++ b/app/components/icon.tsx
@@ -1,0 +1,17 @@
+export interface MyIconProps {
+	mdi: string;
+	size?: "small" | "medium" | "large";
+	className?: string;
+}
+
+export function MyIcon({ mdi, size = "medium", className = "" }: MyIconProps) {
+	const sizeClasses = {
+		small: "text-base",
+		medium: "text-xl",
+		large: "text-2xl",
+	};
+
+	const classes = `mdi mdi-${mdi} ${sizeClasses[size]} ${className}`.trim();
+
+	return <span className={classes} aria-hidden="true" />;
+}

--- a/app/components/layout.spec.tsx
+++ b/app/components/layout.spec.tsx
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "bun:test";
+import { PROJECT_NAME } from "@common/consts";
+import {
+	getElementsByTagName,
+	getTextContent,
+	parseJSXElement,
+} from "@/utils/html-parser";
+import { MyLayout } from "./layout";
+
+describe("MyLayout", () => {
+	it("should render children inside main element", () => {
+		const jsx = (
+			<MyLayout>
+				<div>Test Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const mainElements = getElementsByTagName(root, "main");
+
+		expect(mainElements.length).toBe(1);
+		const main = mainElements[0];
+		if (!main) {
+			throw new Error("Expected main element to exist");
+		}
+		const textContent = getTextContent(main);
+		expect(textContent).toContain("Test Content");
+	});
+
+	it("should not render MyAppBar when showAppBar is false", () => {
+		const jsx = (
+			<MyLayout showAppBar={false}>
+				<div>Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		expect(headers.length).toBe(0);
+	});
+
+	it("should render MyAppBar when showAppBar is undefined (defaults to true)", () => {
+		const jsx = (
+			<MyLayout>
+				<div>Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		expect(headers.length).toBe(1);
+	});
+
+	it("should render MyAppBar when showAppBar is true", () => {
+		const jsx = (
+			<MyLayout showAppBar={true}>
+				<div>Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const headers = getElementsByTagName(root, "header");
+
+		expect(headers.length).toBe(1);
+	});
+
+	it("should pass default title to MyAppBar", () => {
+		const jsx = (
+			<MyLayout showAppBar={true}>
+				<div>Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const h1Elements = getElementsByTagName(root, "h1");
+
+		expect(h1Elements.length).toBe(1);
+		const h1 = h1Elements[0];
+		if (!h1) {
+			throw new Error("Expected h1 element to exist");
+		}
+		expect(getTextContent(h1)).toBe(PROJECT_NAME);
+	});
+
+	it("should pass custom title to MyAppBar", () => {
+		const jsx = (
+			<MyLayout showAppBar={true} title="Custom Title">
+				<div>Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const h1Elements = getElementsByTagName(root, "h1");
+
+		expect(h1Elements.length).toBe(1);
+		const h1 = h1Elements[0];
+		if (!h1) {
+			throw new Error("Expected h1 element to exist");
+		}
+		expect(getTextContent(h1)).toBe("Custom Title");
+	});
+
+	it("should render title even when showAppBar is false", () => {
+		const jsx = (
+			<MyLayout showAppBar={false} title="Page Title">
+				<div>Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const titleElements = getElementsByTagName(root, "title");
+
+		expect(titleElements.length).toBe(1);
+		const title = titleElements[0];
+		if (!title) {
+			throw new Error("Expected title element to exist");
+		}
+		expect(getTextContent(title)).toBe("Page Title");
+	});
+
+	it("should render default title in document head", () => {
+		const jsx = (
+			<MyLayout>
+				<div>Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const titleElements = getElementsByTagName(root, "title");
+
+		expect(titleElements.length).toBe(1);
+		const title = titleElements[0];
+		if (!title) {
+			throw new Error("Expected title element to exist");
+		}
+		expect(getTextContent(title)).toBe(PROJECT_NAME);
+	});
+
+	it("should render custom title in document head", () => {
+		const jsx = (
+			<MyLayout title="My Page">
+				<div>Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const titleElements = getElementsByTagName(root, "title");
+
+		expect(titleElements.length).toBe(1);
+		const title = titleElements[0];
+		if (!title) {
+			throw new Error("Expected title element to exist");
+		}
+		expect(getTextContent(title)).toBe("My Page");
+	});
+
+	it("should render multiple child elements", () => {
+		const jsx = (
+			<MyLayout>
+				<div>First</div>
+				<div>Second</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const mainElements = getElementsByTagName(root, "main");
+
+		const main = mainElements[0];
+		if (!main) {
+			throw new Error("Expected main element to exist");
+		}
+		const textContent = getTextContent(main);
+		expect(textContent).toContain("First");
+		expect(textContent).toContain("Second");
+	});
+
+	it("should include MyAppBar spacer when showAppBar is true", () => {
+		const jsx = (
+			<MyLayout showAppBar={true}>
+				<div>Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const divs = getElementsByTagName(root, "div");
+
+		// MyAppBar includes a spacer div with h-16
+		const spacerDiv = divs.find(
+			(div) =>
+				div.type === "Element" &&
+				div.attributes.class === "h-16" &&
+				div.children.length === 0,
+		);
+
+		expect(spacerDiv).toBeDefined();
+	});
+
+	it("should not include spacer when showAppBar is false", () => {
+		const jsx = (
+			<MyLayout showAppBar={false}>
+				<div>Content</div>
+			</MyLayout>
+		);
+		const root = parseJSXElement(jsx);
+		const divs = getElementsByTagName(root, "div");
+
+		// Should not have the spacer div
+		const spacerDiv = divs.find(
+			(div) =>
+				div.type === "Element" &&
+				div.attributes.class === "h-16" &&
+				div.children.length === 0,
+		);
+
+		expect(spacerDiv).toBeUndefined();
+	});
+});

--- a/app/components/layout.tsx
+++ b/app/components/layout.tsx
@@ -1,5 +1,6 @@
 import { PROJECT_NAME } from "@common/consts";
 import type { JSX } from "hono/jsx/jsx-runtime";
+import ThemeToggle from "@/islands/theme-toggle";
 import { MyAppBar } from "./app-bar";
 
 export interface LayoutProps {
@@ -16,7 +17,7 @@ export function MyLayout({
 	return (
 		<>
 			<title>{title}</title>
-			{showAppBar && <MyAppBar title={title} />}
+			{showAppBar && <MyAppBar title={title} append={<ThemeToggle />} />}
 			<main>{children}</main>
 		</>
 	);

--- a/app/components/layout.tsx
+++ b/app/components/layout.tsx
@@ -1,0 +1,23 @@
+import { PROJECT_NAME } from "@common/consts";
+import type { JSX } from "hono/jsx/jsx-runtime";
+import { MyAppBar } from "./app-bar";
+
+export interface LayoutProps {
+	title?: string;
+	showAppBar?: boolean;
+	children: JSX.Element | Array<JSX.Element>;
+}
+
+export function MyLayout({
+	title = PROJECT_NAME,
+	showAppBar = true,
+	children,
+}: LayoutProps) {
+	return (
+		<>
+			<title>{title}</title>
+			{showAppBar && <MyAppBar title={title} />}
+			<main>{children}</main>
+		</>
+	);
+}

--- a/app/components/switch.spec.tsx
+++ b/app/components/switch.spec.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getElementsByAttribute,
+	getElementsByTagName,
+	parseJSXElement,
+} from "@/utils/html-parser";
+import { MySwitch } from "./switch";
+
+describe("MySwitch", () => {
+	test("renders label with checkbox input", () => {
+		const root = parseJSXElement(<MySwitch />);
+		const labels = getElementsByTagName(root, "label");
+
+		expect(labels.length).toBe(1);
+		const label = labels[0];
+		if (!label) throw new Error("Expected label element to exist");
+
+		const inputs = getElementsByTagName(root, "input");
+		expect(inputs.length).toBe(1);
+		const input = inputs[0];
+		if (!input) throw new Error("Expected input element to exist");
+
+		if (input.type === "Element") {
+			expect(input.attributes.type).toBe("checkbox");
+		}
+	});
+
+	test("applies cursor-pointer to label", () => {
+		const root = parseJSXElement(<MySwitch />);
+		const labels = getElementsByTagName(root, "label");
+
+		const label = labels[0];
+		if (!label) throw new Error("Expected label element to exist");
+
+		if (label.type === "Element") {
+			expect(label.attributes.class).toContain("cursor-pointer");
+		}
+	});
+
+	test("checkbox has sr-only class for accessibility", () => {
+		const root = parseJSXElement(<MySwitch />);
+		const inputs = getElementsByTagName(root, "input");
+
+		const input = inputs[0];
+		if (!input) throw new Error("Expected input element to exist");
+
+		if (input.type === "Element") {
+			expect(input.attributes.class).toContain("sr-only");
+		}
+	});
+
+	test("renders toggle switch div element", () => {
+		const root = parseJSXElement(<MySwitch />);
+		const divs = getElementsByTagName(root, "div");
+
+		expect(divs.length).toBeGreaterThan(0);
+		const toggleDiv = divs[0];
+		if (!toggleDiv) throw new Error("Expected div element to exist");
+
+		if (toggleDiv.type === "Element") {
+			expect(toggleDiv.attributes.class).toContain("w-11");
+			expect(toggleDiv.attributes.class).toContain("h-6");
+			expect(toggleDiv.attributes.class).toContain("rounded-full");
+		}
+	});
+
+	test("renders prepend element when provided", () => {
+		const root = parseJSXElement(
+			<MySwitch prepend={<span class="prepend-test">Left</span>} />,
+		);
+		const spans = getElementsByAttribute(root, "class", "prepend-test");
+
+		expect(spans.length).toBe(1);
+		const span = spans[0];
+		if (!span) throw new Error("Expected prepend span to exist");
+	});
+
+	test("renders append element when provided", () => {
+		const root = parseJSXElement(
+			<MySwitch append={<span class="append-test">Right</span>} />,
+		);
+		const spans = getElementsByAttribute(root, "class", "append-test");
+
+		expect(spans.length).toBe(1);
+		const span = spans[0];
+		if (!span) throw new Error("Expected append span to exist");
+	});
+
+	test("renders both prepend and append elements", () => {
+		const root = parseJSXElement(
+			<MySwitch
+				prepend={<span class="prepend-icon">P</span>}
+				append={<span class="append-icon">A</span>}
+			/>,
+		);
+
+		const prependSpans = getElementsByAttribute(root, "class", "prepend-icon");
+		const appendSpans = getElementsByAttribute(root, "class", "append-icon");
+
+		expect(prependSpans.length).toBe(1);
+		expect(appendSpans.length).toBe(1);
+
+		if (!prependSpans[0]) throw new Error("Expected prepend span to exist");
+		if (!appendSpans[0]) throw new Error("Expected append span to exist");
+	});
+
+	test("applies flex layout for proper alignment", () => {
+		const root = parseJSXElement(<MySwitch />);
+		const labels = getElementsByTagName(root, "label");
+
+		const label = labels[0];
+		if (!label) throw new Error("Expected label element to exist");
+
+		if (label.type === "Element") {
+			expect(label.attributes.class).toContain("inline-flex");
+			expect(label.attributes.class).toContain("items-center");
+			expect(label.attributes.class).toContain("gap-2");
+		}
+	});
+
+	test("toggle switch has peer class for state management", () => {
+		const root = parseJSXElement(<MySwitch />);
+		const inputs = getElementsByTagName(root, "input");
+
+		const input = inputs[0];
+		if (!input) throw new Error("Expected input element to exist");
+
+		if (input.type === "Element") {
+			expect(input.attributes.class).toContain("peer");
+		}
+	});
+
+	test("toggle switch has checked state styling", () => {
+		const root = parseJSXElement(<MySwitch />);
+		const divs = getElementsByTagName(root, "div");
+
+		const toggleDiv = divs[0];
+		if (!toggleDiv) throw new Error("Expected div element to exist");
+
+		if (toggleDiv.type === "Element") {
+			expect(toggleDiv.attributes.class).toContain("peer-checked:bg-blue-600");
+			expect(toggleDiv.attributes.class).toContain(
+				"peer-checked:after:translate-x-full",
+			);
+		}
+	});
+});

--- a/app/components/switch.spec.tsx
+++ b/app/components/switch.spec.tsx
@@ -144,4 +144,82 @@ describe("MySwitch", () => {
 			);
 		}
 	});
+
+	test("renders with checked prop", () => {
+		const root = parseJSXElement(<MySwitch checked={true} />);
+		const inputs = getElementsByTagName(root, "input");
+
+		const input = inputs[0];
+		if (!input) throw new Error("Expected input element to exist");
+
+		if (input.type === "Element") {
+			expect(input.attributes.checked).toBe(true);
+		}
+	});
+
+	test("renders with unchecked prop", () => {
+		const root = parseJSXElement(<MySwitch checked={false} />);
+		const inputs = getElementsByTagName(root, "input");
+
+		const input = inputs[0];
+		if (!input) throw new Error("Expected input element to exist");
+
+		if (input.type === "Element") {
+			// checked={false} is typically omitted from HTML attributes
+			// The presence of the input without checked attribute indicates unchecked state
+			expect(input.attributes.checked).toBeUndefined();
+		}
+	});
+
+	test("renders without checked prop defaults to undefined", () => {
+		const root = parseJSXElement(<MySwitch />);
+		const inputs = getElementsByTagName(root, "input");
+
+		const input = inputs[0];
+		if (!input) throw new Error("Expected input element to exist");
+
+		if (input.type === "Element") {
+			expect(input.attributes.checked).toBeUndefined();
+		}
+	});
+
+	test("supports controlled component with checked prop", () => {
+		// Test that checked prop can be passed (for controlled components)
+		const rootChecked = parseJSXElement(<MySwitch checked={true} />);
+		const inputsChecked = getElementsByTagName(rootChecked, "input");
+		const inputChecked = inputsChecked[0];
+
+		if (!inputChecked) throw new Error("Expected input element to exist");
+		if (inputChecked.type === "Element") {
+			expect(inputChecked.attributes.checked).toBe(true);
+		}
+
+		const rootUnchecked = parseJSXElement(<MySwitch checked={false} />);
+		const inputsUnchecked = getElementsByTagName(rootUnchecked, "input");
+		const inputUnchecked = inputsUnchecked[0];
+
+		if (!inputUnchecked) throw new Error("Expected input element to exist");
+		if (inputUnchecked.type === "Element") {
+			// In HTML, checked={false} typically doesn't render the attribute
+			expect(
+				inputUnchecked.attributes.checked === undefined ||
+					inputUnchecked.attributes.checked === false,
+			).toBe(true);
+		}
+	});
+
+	test("accepts onChange prop for controlled component", () => {
+		// Test that onChange prop can be passed without errors
+		const handleChange = (_checked: boolean) => {
+			// Mock handler - in actual runtime this would be called
+		};
+
+		// This should not throw an error
+		const root = parseJSXElement(<MySwitch onChange={handleChange} />);
+		const inputs = getElementsByTagName(root, "input");
+
+		expect(inputs.length).toBe(1);
+		const input = inputs[0];
+		if (!input) throw new Error("Expected input element to exist");
+	});
 });

--- a/app/components/switch.tsx
+++ b/app/components/switch.tsx
@@ -1,0 +1,25 @@
+import type { JSX } from "hono/jsx/jsx-runtime";
+
+export interface MySwitchProps {
+	prepend?:
+		| JSX.Element
+		| Array<JSX.Element>
+		| string
+		| Array<JSX.Element | string>;
+	append?:
+		| JSX.Element
+		| Array<JSX.Element>
+		| string
+		| Array<JSX.Element | string>;
+}
+
+export function MySwitch({ prepend, append }: MySwitchProps) {
+	return (
+		<label class="inline-flex items-center gap-2 cursor-pointer">
+			{prepend}
+			<input type="checkbox" class="sr-only peer" />
+			<div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600" />
+			{append}
+		</label>
+	);
+}

--- a/app/components/switch.tsx
+++ b/app/components/switch.tsx
@@ -1,6 +1,8 @@
 import type { JSX } from "hono/jsx/jsx-runtime";
 
 export interface MySwitchProps {
+	checked?: boolean;
+	onChange?: (checked: boolean) => void;
 	prepend?:
 		| JSX.Element
 		| Array<JSX.Element>
@@ -13,11 +15,26 @@ export interface MySwitchProps {
 		| Array<JSX.Element | string>;
 }
 
-export function MySwitch({ prepend, append }: MySwitchProps) {
+export function MySwitch({
+	checked,
+	onChange,
+	prepend,
+	append,
+}: MySwitchProps) {
 	return (
 		<label class="inline-flex items-center gap-2 cursor-pointer">
 			{prepend}
-			<input type="checkbox" class="sr-only peer" />
+			<input
+				type="checkbox"
+				class="sr-only peer"
+				checked={checked}
+				onChange={(e) => {
+					const target = e.currentTarget;
+					if (target instanceof HTMLInputElement) {
+						onChange?.(target.checked);
+					}
+				}}
+			/>
 			<div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600" />
 			{append}
 		</label>

--- a/app/islands/theme-toggle.tsx
+++ b/app/islands/theme-toggle.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "hono/jsx";
+import { MyIcon } from "@/components/icon";
+import { MySwitch } from "@/components/switch";
+
+export default function ThemeToggle() {
+	const [isDark, setIsDark] = useState(false);
+
+	useEffect(() => {
+		// Get initial theme from localStorage or browser preference
+		const stored = localStorage.getItem("theme");
+		const prefersDark = window.matchMedia(
+			"(prefers-color-scheme: dark)",
+		).matches;
+		const initialDark = stored === "dark" || (!stored && prefersDark);
+
+		setIsDark(initialDark);
+		document.documentElement.classList.toggle("dark", initialDark);
+	}, []);
+
+	const handleToggle = (checked: boolean) => {
+		setIsDark(checked);
+		document.documentElement.classList.toggle("dark", checked);
+		localStorage.setItem("theme", checked ? "dark" : "light");
+	};
+
+	return (
+		<>
+			<span>{isDark}</span>
+			<MySwitch
+				checked={isDark}
+				onChange={handleToggle}
+				prepend={<MyIcon mdi="weather-sunny" size="small" />}
+				append={<MyIcon mdi="weather-night" size="small" />}
+			/>
+		</>
+	);
+}

--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -1,6 +1,16 @@
 import { jsxRenderer } from "hono/jsx-renderer";
 import { Link, Script } from "honox/server";
 
+const themeScript = `
+(function() {
+	const theme = localStorage.getItem('theme') || 
+		(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+	if (theme === 'dark') {
+		document.documentElement.classList.add('dark');
+	}
+})();
+`;
+
 export default jsxRenderer(({ children }) => {
 	return (
 		<html lang="ja">
@@ -9,6 +19,8 @@ export default jsxRenderer(({ children }) => {
 				<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 				<title>albatross</title>
 				<link rel="icon" href="/favicon.svg" />
+				{/* biome-ignore lint: Safe static script to prevent theme flash */}
+				<script dangerouslySetInnerHTML={{ __html: themeScript }} />
 				<Link href="/app/style.css" rel="stylesheet" />
 				<Script src="/app/client.ts" async />
 			</head>

--- a/app/routes/birds.tsx
+++ b/app/routes/birds.tsx
@@ -10,6 +10,7 @@ import {
 } from "@db/schemas";
 import { eq, sql } from "drizzle-orm";
 import { createRoute } from "honox/factory";
+import { MyLayout } from "@/components/layout";
 import BirdsTable, { type BirdRow } from "@/islands/birds-table";
 
 export default createRoute(async (c) => {
@@ -50,13 +51,12 @@ export default createRoute(async (c) => {
 	}));
 
 	return c.render(
-		<>
-			<title>野鳥一覧</title>
-			<h1 className="text-center mt-8">野鳥一覧</h1>
-			<h2 className="text-center mb-8">いま見つけられる野鳥を探そう</h2>
-			<div className="max-w-7xl mx-auto px-4">
+		<MyLayout>
+			<h2 className="text-center mt-6">野鳥一覧</h2>
+			<h3 className="text-center mt-6">いま見つけられる野鳥を探そう</h3>
+			<div className="max-w-7xl mt-8 mx-auto px-4">
 				<BirdsTable birds={birds} />
 			</div>
-		</>,
+		</MyLayout>,
 	);
 });

--- a/app/style.css
+++ b/app/style.css
@@ -7,10 +7,14 @@
 	}
 
 	h1 {
-		@apply text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6;
+		@apply text-3xl font-bold text-gray-900 dark:text-gray-100;
 	}
 
 	h2 {
-		@apply text-2xl font-semibold text-gray-800 dark:text-gray-200 mb-4;
+		@apply text-3xl font-bold text-gray-900 dark:text-gray-100;
+	}
+
+	h3 {
+		@apply text-2xl font-semibold text-gray-800 dark:text-gray-200;
 	}
 }

--- a/app/style.css
+++ b/app/style.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 @import "@mdi/font/css/materialdesignicons.min.css";
 
+@variant dark (&:where(.dark, .dark *));
+
 @layer base {
 	body {
 		@apply bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100;

--- a/app/style.css
+++ b/app/style.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "@mdi/font/css/materialdesignicons.min.css";
 
 @layer base {
 	body {

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "albatross",
       "dependencies": {
+        "@mdi/font": "^7.4.47",
         "drizzle-orm": "latest",
         "hono": "latest",
         "honox": "latest",
@@ -224,6 +225,8 @@
     "@libsql/linux-x64-musl": ["@libsql/linux-x64-musl@0.5.22", "", { "os": "linux", "cpu": "x64" }, "sha512-UZ4Xdxm4pu3pQXjvfJiyCzZop/9j/eA2JjmhMaAhe3EVLH2g11Fy4fwyUp9sT1QJYR1kpc2JLuybPM0kuXv/Tg=="],
 
     "@libsql/win32-x64-msvc": ["@libsql/win32-x64-msvc@0.5.22", "", { "os": "win32", "cpu": "x64" }, "sha512-Fj0j8RnBpo43tVZUVoNK6BV/9AtDUM5S7DF3LB4qTYg1LMSZqi3yeCneUTLJD6XomQJlZzbI4mst89yspVSAnA=="],
+
+    "@mdi/font": ["@mdi/font@7.4.47", "", {}, "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw=="],
 
     "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 

--- a/common/src/consts.ts
+++ b/common/src/consts.ts
@@ -1,2 +1,4 @@
+export const PROJECT_NAME = "albatross";
+
 export const ERROR_MESSAGE_ENV_NOT_SET = "Environment variable is not set";
 export const DB_SYSTEM_USER = "system";

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"deploy:prod": "vite build --mode client && vite build && wrangler deploy"
 	},
 	"dependencies": {
+		"@mdi/font": "^7.4.47",
 		"drizzle-orm": "latest",
 		"hono": "latest",
 		"honox": "latest"


### PR DESCRIPTION
Closes #8

## Overview
Implemented dark mode toggle functionality in the application bar with proper theme persistence and FOUC prevention.

## Changes
- Added MyIcon component with Material Design Icons support (#9)
- Added MySwitch component with controlled component props (#10)
- Added ThemeToggle island component for client-side theme switching (#11)
- Added MyLayout component with MyAppBar integration (#12)
- Updated heading hierarchy for semantic HTML (#13)
- Configured Tailwind v4 dark mode with @variant directive
- Prevented theme flash on page load with inline script

## Testing
- All 91 tests passing
- Type checking passes
- Linter passes with appropriate ignore comments

## Related Issues
- Closes #8
- Closes #9
- Closes #10
- Closes #11
- Closes #12
- Closes #13